### PR TITLE
Shortest paths comparisons

### DIFF
--- a/assign1.py
+++ b/assign1.py
@@ -81,6 +81,8 @@ def reduce_graph(G, M, N, draw = True):
     for node in all_nodes_list:
         if node[1] == 's':
             all_data_nodes.append(node)
+    # Since we already computed ctr (yellow) above, we can add that to the list
+    all_data_nodes.append((ctr, 'd-ctr'))
     all_data_nodes_length = len(all_data_nodes)
 
     # NOTE, we might be able to use just this: multi_source_dijkstra_path(G, sources) Find shortest weighted paths in G from a given set of source nodes.

--- a/assign1.py
+++ b/assign1.py
@@ -60,7 +60,7 @@ def set_node_colors(G):
     for i in range(G.order()):
         role = G.nodes[i]['wrk']
         if   role == 'd': colors.append('white')         # no data node
-        elif role == 'd-ctr': colors.append('yellow')    # graph center 
+        elif role == 'd-ctr': colors.append('yellow')    # graph center
         elif role == 's': colors.append('red')           # data node
         elif role == 's-ctr': colors.append('skyblue')   # subgraph center
         elif role == 'r-ctr': colors.append('blue')      # reduced graph center
@@ -75,9 +75,12 @@ def reduce_graph(G, M, N, draw = True):
     G.nodes[ctr]['wrk'] = 'd-ctr'
 
     # realize a logic to reduce the network based on find MST
-    G = nx.minimum_spanning_tree(G) 
+    G = nx.minimum_spanning_tree(G)
+    mst_ctr = find_center_node(G)[0]
+    G.nodes[mst_ctr]['wrk'] = 'r-ctr'
+
     all_nodes_list = list(G.nodes.data('wrk'))
-    all_data_nodes = list() # Get all the red nodes. 
+    all_data_nodes = list() # Get all the red nodes.
     for node in all_nodes_list:
         if node[1] == 's':
             all_data_nodes.append(node)
@@ -86,10 +89,10 @@ def reduce_graph(G, M, N, draw = True):
     all_data_nodes_length = len(all_data_nodes)
 
     # NOTE, we might be able to use just this: multi_source_dijkstra_path(G, sources) Find shortest weighted paths in G from a given set of source nodes.
-    # NOTE this might not work because its returning to all nodes. WE only care about red nodes. 
+    # NOTE this might not work because its returning to all nodes. WE only care about red nodes.
     # all_shortest_paths = multi_source_dijkstra_path_length
 
-    # Out of all the methods, dijsktra's path seems to be the one of most fit. 
+    # Out of all the methods, dijsktra's path seems to be the one of most fit.
 
     #Once we connect i to j, we don't need to connect j to i (Its already there)
     all_shortest_paths = list()
@@ -108,11 +111,11 @@ def reduce_graph(G, M, N, draw = True):
             # print(node)
             # print(G.nodes[node]['wrk'])
 
-    #Generate all edge pairs between red + shortest paths. 
+    #Generate all edge pairs between red + shortest paths.
     # remove all edge pairs from current graph
         # we can create a copy: nx.create_empty_copy(G, with_data=True)
     new_graph_2 = nx.create_empty_copy(G)
-    # add in "new" edge pairs. 
+    # add in "new" edge pairs.
     for path_of_nodes in all_shortest_paths:
         if len(path_of_nodes) > 1: #ie only save pathed nodes, cause we have list of just single red.
             for i in range (0, len(path_of_nodes)-1): #Notice we stop one before because we are connecting i to i+1
@@ -125,16 +128,16 @@ def reduce_graph(G, M, N, draw = True):
     # for i in range (0, N):
     #     if i not in nodes_in_new_graph:
     #         new_graph.add_node(i, wrk=G.nodes[i]['wrk'])
-    
-    # # After adding the nodes, we must add the edges. 
+
+    # # After adding the nodes, we must add the edges.
     # for path_of_nodes in all_shortest_paths:
     #     if len(path_of_nodes) > 1: #ie only save pathed nodes, cause we have list of just single red.
     #         for i in range (0, len(path_of_nodes)-1): #Notice we stop one before because we are connecting i to i+1
     #             new_graph.add_edge(path_of_nodes[i], path_of_nodes[i+1])
 
-    # # We are still mising the white nodes not in the path, and thus need to figure out which those are and add them. 
+    # # We are still mising the white nodes not in the path, and thus need to figure out which those are and add them.
     # G=new_graph
-   
+
     G = new_graph_2
 
     if draw:  # draw an original graph with a network center
@@ -148,13 +151,13 @@ def reduce_graph(G, M, N, draw = True):
         for n in range(G.order()): labels[n] = str(n)
         nx.draw_networkx_labels(G, pos, labels, font_size = 10)
 
-    
+
     if draw:
         plt.xlim(-0.05, 1.05)
         plt.ylim(-0.05, 1.05)
         # plt.axis('off')
         plt.show(block = False)
-    return G 
+    return G
 
 
 
@@ -164,10 +167,10 @@ def reduce_all_ones(G):
 
 def simulation(N, M, D, d_min, d_max, d_M, round_per_graph, draw = False):
     ''' N is a total number of node, M is a server node, D is a RGG's distance
-    parameter, a uniform [d_max, d_min] is a generated data size to exchange, 
-    d_M is the number of data generating servres, round_per_graph is the 
-    number of iterations per a generated graph, and drwa is to decide if the 
-    graph is gerated or not. ''' 
+    parameter, a uniform [d_max, d_min] is a generated data size to exchange,
+    d_M is the number of data generating servres, round_per_graph is the
+    number of iterations per a generated graph, and drwa is to decide if the
+    graph is gerated or not. '''
     print("-- (N, M) = (" + str(N) + ", " + str(M) + ")", "D =", D,
           "data =[" + str(d_min) + " ," + str(d_max) + "]",
           "Data Senders =", d_M, "Per Graph =", round_per_graph)

--- a/assign1.py
+++ b/assign1.py
@@ -68,69 +68,76 @@ def set_node_colors(G):
     # print("Length =", len(colors), colors)
     return colors
 
-def testremoval(G,M,X,Y):
-    G.remove_edge(X,Y)
-    print(str(X)+" "+str(Y) + "removed")
-    container = list(nx.algorithms.dag.descendants(G,0))
-    for x in range(1, M):
-        if not x in container:
-            return False
-    else:
-        return True
-
-def checkconnection(G,M):
-    container = list(nx.algorithms.dag.descendants(G,0))
-    for x in range(1, M):
-        if not x in container:
-            return False
-    else:
-        return True
-
-def reduce_graph(G, M, draw = True):
+def reduce_graph(G, M, N, draw = True):
     ''' G will be reduced to M-node,data server only, graph '''
-    G = nx.minimum_spanning_tree(G) 
     pos = nx.get_node_attributes(G, 'pos')
     ctr = find_center_node(G)[0]
     G.nodes[ctr]['wrk'] = 'd-ctr'
+
+    # realize a logic to reduce the network based on find MST
+    G = nx.minimum_spanning_tree(G) 
+    all_nodes_list = list(G.nodes.data('wrk'))
+    all_data_nodes = list() # Get all the red nodes. 
+    for node in all_nodes_list:
+        if node[1] == 's':
+            all_data_nodes.append(node)
+    all_data_nodes_length = len(all_data_nodes)
+
+    # NOTE, we might be able to use just this: multi_source_dijkstra_path(G, sources) Find shortest weighted paths in G from a given set of source nodes.
+    # NOTE this might not work because its returning to all nodes. WE only care about red nodes. 
+    # all_shortest_paths = multi_source_dijkstra_path_length
+
+    # Out of all the methods, dijsktra's path seems to be the one of most fit. 
+
+    #Once we connect i to j, we don't need to connect j to i (Its already there)
+    all_shortest_paths = list()
+    for i in range (0, all_data_nodes_length):
+        for j in range(i, all_data_nodes_length):
+            shortest_path_i_j = nx.dijkstra_path(G, all_data_nodes[i][0], all_data_nodes[j][0])
+            all_shortest_paths.append(shortest_path_i_j)
+
+    nodes_in_new_graph = set()
+    new_graph = nx.Graph()
+    for path_of_nodes in all_shortest_paths:
+        for node in path_of_nodes:
+            # NOTE -- might not need this code anymore, but keeping her just cause.
+            new_graph.add_node(node, wrk=G.nodes[node]['wrk'])
+            nodes_in_new_graph.add(node)
+            # print(node)
+            # print(G.nodes[node]['wrk'])
+
+    #Generate all edge pairs between red + shortest paths. 
+    # remove all edge pairs from current graph
+        # we can create a copy: nx.create_empty_copy(G, with_data=True)
+    new_graph_2 = nx.create_empty_copy(G)
+    # add in "new" edge pairs. 
+    for path_of_nodes in all_shortest_paths:
+        if len(path_of_nodes) > 1: #ie only save pathed nodes, cause we have list of just single red.
+            for i in range (0, len(path_of_nodes)-1): #Notice we stop one before because we are connecting i to i+1
+                new_graph_2.add_edge(path_of_nodes[i], path_of_nodes[i+1])
+
+    # #nodes_in_new_graph.sort()
+    # # ### NOTE, this changes the type to a list
+    # # nodes_in_new_graph = sorted(nodes_in_new_graph)
+    # print(nodes_in_new_graph)
+    # for i in range (0, N):
+    #     if i not in nodes_in_new_graph:
+    #         new_graph.add_node(i, wrk=G.nodes[i]['wrk'])
     
+    # # After adding the nodes, we must add the edges. 
+    # for path_of_nodes in all_shortest_paths:
+    #     if len(path_of_nodes) > 1: #ie only save pathed nodes, cause we have list of just single red.
+    #         for i in range (0, len(path_of_nodes)-1): #Notice we stop one before because we are connecting i to i+1
+    #             new_graph.add_edge(path_of_nodes[i], path_of_nodes[i+1])
+
+    # # We are still mising the white nodes not in the path, and thus need to figure out which those are and add them. 
+    # G=new_graph
+   
+    G = new_graph_2
 
     if draw:  # draw an original graph with a network center
         plt1 = plt.figure(figsize=(15, 15))
         colors = set_node_colors(G)
-
-        # Check if node only occurs once in list of edges. If yes, remove edge
-        node_count = len(G.nodes)
-        edges = G.edges()
-        connection_counts = {}
-
-        # Creates a dictionary that lists all the nodes a node is connected to (no duplicates)
-        for node in range(0, node_count):
-            for edge in edges:
-                if node == edge[0] and edge[0] not in range(0, M):
-                    if node in connection_counts:
-                        connection_counts[node] += [edge[1]]
-                    else:
-                        connection_counts[node] = [edge[1]]
-
-        for elem in connection_counts.keys():
-            if len(connection_counts[elem]) == 1:
-                G.remove_edge(elem, connection_counts[elem][0])
-
-        # for edge in edges:
-        #     if edge[0] or edge[1] not in range(0, M):
-        #         if edge[0] in connection_counts:
-        #             connection_counts[edge[0]] += [edge[1]]
-        #         else:
-        #             connection_counts[edge[0]] = [edge[1]]
-        
-        # for elem in connection_counts.keys():
-        #     if len(connection_counts[elem]) == 1:
-        #         G.remove_edge(elem, connection_counts[elem][0])
-
-
-                # if not checkconnection(G, M):
-                #     G.add_edge(elem, connection_counts[elem])
-
         nx.draw_networkx_nodes(G, pos, node_size = 160,
                                node_color = colors, edgecolors = 'gray',
                                cmap = plt.cm.Reds_r)
@@ -139,7 +146,6 @@ def reduce_graph(G, M, draw = True):
         for n in range(G.order()): labels[n] = str(n)
         nx.draw_networkx_labels(G, pos, labels, font_size = 10)
 
-    # realize a logic to reduce the network based on find MST
     
     if draw:
         plt.xlim(-0.05, 1.05)
@@ -147,6 +153,12 @@ def reduce_graph(G, M, draw = True):
         # plt.axis('off')
         plt.show(block = False)
     return G 
+
+
+
+def reduce_all_ones(G):
+    non_red_nodes = list(G.nodes.data('wrk'))
+    print(non_red_nodes)
 
 def simulation(N, M, D, d_min, d_max, d_M, round_per_graph, draw = False):
     ''' N is a total number of node, M is a server node, D is a RGG's distance
@@ -159,8 +171,9 @@ def simulation(N, M, D, d_min, d_max, d_M, round_per_graph, draw = False):
           "Data Senders =", d_M, "Per Graph =", round_per_graph)
     # rnd.seed(999)
     G = generate_graph(N, M, D)
-    G = reduce_graph(G, M, draw)
+    G = reduce_graph(G, M, N, draw) ##NOTE added N parameter to help simplify adding missing white nodes.
     # rest is your work...
 
 simulation(200, 20, 0.125, 10, 100, 10, 10, True)
 plt.show()
+


### PR DESCRIPTION
Please review current algorithms used and the approach. (Might not be the most efficent but it suffices.)

- get all of the red nodes 
- Add in yellow node that was previous computed to this list
- compute all shortest paths between red/yellow nodes.
- Generate an empty copy graph (want to maintain the same structure)
- add in all the edges to empty graph of shortest paths (networkx "should" disregard duplicate edges, this way we do not need to parse out duplicates ourselves) 

====
Notice, I removed all the code currently on master. 

Notice, I used dijsktra path as it was the one algorithm where we can manually select source and target (ie the s and d-ctr nodes). Other algorithms such as all_shortest_path find paths from a given source to ever single node (and we are not concerned with majority of the N nodes). 